### PR TITLE
Add basic Node.js login server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ To host the planner on an Ubuntu server:
 3. Enable HTTPS so the service worker can schedule persistent reminders. Tools like **Let's Encrypt** make it easy to obtain free certificates.
 4. For local development you can simply use `http://localhost`, which counts as a secure origin for service workers.
 
+## Server-side Login
+This repository now includes a small Node.js server that provides a
+basic login system. To start the server run:
+
+```bash
+node server.js
+```
+
+The default credentials are `admin` / `admin`. After starting the server
+navigate to `http://localhost:3000` and log in. The planner will only be
+accessible once logged in, and the session persists across page reloads
+until you log out.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/login.html
+++ b/login.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <style>
+    body {
+      background-color: #121212;
+      color: #e0e0e0;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      padding: 1em;
+    }
+    input {
+      margin: 0.5em 0;
+      background-color: #1e1e1e;
+      border: 1px solid #333;
+      color: #e0e0e0;
+      padding: 0.5em;
+    }
+    button {
+      background-color: #bb86fc;
+      border: none;
+      padding: 0.5em 1em;
+      color: #000;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="POST" action="/login">
+    <div>
+      <label>Username:<br>
+      <input type="text" name="username" required></label>
+    </div>
+    <div>
+      <label>Password:<br>
+      <input type="password" name="password" required></label>
+    </div>
+    <button type="submit">Login</button>
+  </form>
+  <div id="error" style="color:#f44336;"></div>
+  <script>
+    const params = new URLSearchParams(location.search);
+    if (params.get('error')) {
+      document.getElementById('error').textContent = 'Invalid credentials';
+    }
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "todogoals-advanced",
+  "version": "1.0.0",
+  "description": "A minimal dark-mode, browser-based task planner that supports:",
+  "main": "service-worker.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,115 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const querystring = require('querystring');
+
+const PORT = process.env.PORT || 3000;
+const sessions = {};
+
+function loadUsers() {
+  try {
+    const data = fs.readFileSync(path.join(__dirname, 'users.json'), 'utf-8');
+    return JSON.parse(data);
+  } catch (e) {
+    return {};
+  }
+}
+
+const users = loadUsers();
+
+function hashPwd(pwd) {
+  return crypto.createHash('sha256').update(pwd).digest('hex');
+}
+
+function auth(username, password) {
+  const hashed = hashPwd(password);
+  return users[username] && users[username] === hashed;
+}
+
+function parseCookies(req) {
+  const list = {};
+  const cookie = req.headers.cookie;
+  if (!cookie) return list;
+  cookie.split(';').forEach(pair => {
+    const parts = pair.split('=');
+    list[parts.shift().trim()] = decodeURIComponent(parts.join('='));
+  });
+  return list;
+}
+
+function serveFile(res, filepath, contentType = 'text/html', status = 200) {
+  fs.readFile(filepath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(status, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+function serveStatic(req, res) {
+  let filePath = path.join(__dirname, req.url);
+  if (req.url === '/') filePath = path.join(__dirname, 'index.html');
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes = {
+    '.js': 'text/javascript',
+    '.css': 'text/css',
+    '.html': 'text/html',
+    '.json': 'application/json'
+  };
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+  serveFile(res, filePath, contentType);
+}
+
+const server = http.createServer((req, res) => {
+  const cookies = parseCookies(req);
+  const session = sessions[cookies.session];
+
+  if (['/', '/index.html', '/to_do_goals.html'].includes(req.url) && !session) {
+    res.writeHead(302, { Location: '/login.html' });
+    return res.end();
+  }
+
+  if (req.url === '/login.html' && req.method === 'GET') {
+    return serveFile(res, path.join(__dirname, 'login.html'));
+  }
+
+  if (req.url === '/login' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => (body += chunk.toString()));
+    req.on('end', () => {
+      const parsed = querystring.parse(body);
+      if (auth(parsed.username, parsed.password)) {
+        const id = crypto.randomBytes(16).toString('hex');
+        sessions[id] = parsed.username;
+        res.writeHead(302, {
+          'Set-Cookie': `session=${id}; HttpOnly`,
+          Location: '/to_do_goals.html'
+        });
+        res.end();
+      } else {
+        res.writeHead(302, { Location: '/login.html?error=1' });
+        res.end();
+      }
+    });
+    return;
+  }
+
+  if (req.url === '/logout') {
+    if (cookies.session) delete sessions[cookies.session];
+    res.writeHead(302, {
+      'Set-Cookie': 'session=; Max-Age=0',
+      Location: '/login.html'
+    });
+    return res.end();
+  }
+
+  serveStatic(req, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/users.json
+++ b/users.json
@@ -1,0 +1,3 @@
+{
+  "admin": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+}


### PR DESCRIPTION
## Summary
- add simple Node server for login with cookie-based sessions
- create `login.html` page
- store a default user in `users.json`
- document server usage and login credentials

## Testing
- `node server.js` (started server)
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8c0ac2083229063fec65243b0fe